### PR TITLE
Modify Modularized

### DIFF
--- a/src/Server.java
+++ b/src/Server.java
@@ -54,19 +54,41 @@ public class Server {
     }
 
     /**
-     * Returns current server time (0-24000)
+     * Returns actual server time (-2^63 to 2^63-1)
      * @return time server time
      */
     public long getTime() {
-        return server.e.c;
+       return server.e.c;
+    }
+    
+    /**
+     * Returns current server time (0-24000)
+     * @return time server time
+     */
+    public long getRelativeTime() {
+   	 long time = (server.e.c % 24000);
+   	 if (time < 0) // Java modulus is stupid.
+   		 time += 24000;
+       return time;
     }
 
+    /**
+     * Sets the actual server time
+     * @param time time (-2^63 to 2^63-1)
+     */
+    public void setTime(long time) {
+       server.e.c = time;
+    }
+    
     /**
      * Sets the current server time
      * @param time time (0-24000)
      */
-    public void setTime(long time) {
-        server.e.c = time;
+    public void setRelativeTime(long time) {
+       long margin = (time - server.e.c) % 24000;
+       if (margin < 0) // Java modulus is stupid.
+ 			margin += 24000;
+       server.e.c += margin;
     }
 
     /**

--- a/src/etc.java
+++ b/src/etc.java
@@ -65,7 +65,7 @@ public class etc {
         commands.put("/removewarp", "[Warp] - Removes the specified warp.");
         commands.put("/getpos", "- Displays your current position.");
         commands.put("/compass", "- Gives you a compass reading.");
-        commands.put("/time", "[Time|day|night] - Changes time");
+        commands.put("/time", "[time|'day|night|check|raw'] (rawtime) - Changes or checks the time");
         commands.put("/lighter", "- Gives you a lighter for lighting furnaces");
         commands.put("/motd", "- Displays the MOTD");
         commands.put("/modify", "[player] [key] [value] - Type /modify for more info");

--- a/src/id.java
+++ b/src/id.java
@@ -1062,21 +1062,31 @@ public class id extends ej
                 a.info(getPlayer().getName() + " issued server command: " + str);
                 this.d.a(str, this);
             } else if (split[0].equalsIgnoreCase("/time")) {
-                if (split.length != 2) {
-                    msg(Colors.Rose + "Correct usage is: /time [time|day|night]");
-                    return;
-                }
-
-                if (split[1].equalsIgnoreCase("day")) {
-                    this.d.e.c = 0;
-                } else if (split[1].equalsIgnoreCase("night")) {
-                    this.d.e.c = 13000;
+                if (split.length == 2) {
+	                if (split[1].equalsIgnoreCase("day")) {
+	               	 etc.getServer().setRelativeTime(0);
+	                } else if (split[1].equalsIgnoreCase("night")) {
+	               	 etc.getServer().setRelativeTime(13000);
+	                } else if (split[1].equalsIgnoreCase("check")) {
+	               	 msg(Colors.Rose + "The time is "+etc.getServer().getRelativeTime()+"! (RAW: "+etc.getServer().getTime()+")");
+	                } else {
+							try {
+								etc.getServer().setRelativeTime(Long.parseLong(split[1]));
+							} catch (NumberFormatException ex) {
+								msg(Colors.Rose + "Please enter numbers, not letters.");
+							}
+	                }
+                } else if (split.length == 3) {
+               	 if (split[1].equalsIgnoreCase("raw")) {
+	               	 try {
+	                	  	etc.getServer().setTime(Long.parseLong(split[2]));
+	                  } catch (NumberFormatException ex) {
+	                      msg(Colors.Rose + "Please enter numbers, not letters.");
+	                  }
+	                }
                 } else {
-                    try {
-                        this.d.e.c = Long.parseLong(split[1]);
-                    } catch (NumberFormatException ex) {
-                        msg(Colors.Rose + "Please enter numbers, not letters.");
-                    }
+               	 msg(Colors.Rose + "Correct usage is: /time [time|'day|night|check|raw'] (rawtime)");
+                   return;
                 }
             } else if (split[0].equalsIgnoreCase("/getpos")) {
                 Player p = getPlayer();


### PR DESCRIPTION
EvilSeph ( and apparently some other players ) requested the following...

> "I've been kicking around this idea and I also noticed a few users have been asking for it too, so I decided to post a request for it to see if there was any interest and how feasible it would be:
> Currently the /modify command requires the user to use multiple commands to achieve what they want (usually).
> /modify player group|g admins,mods
> /modify player admin|a true
> /modify player ignorerestrictions|ir true
> /modify player modworld|mw true
> /modify player commands|c /listwarps,/who
> /modify player prefix|p c
> I was wondering if it would be possible to change the /modify command (or provide an enhanced version of it) to work something like the following:
> /modify g:admins,mods a:true ir:true mw:true p:c c:/listwarps,who
> Basically consolidate it into one command. Preferably have no specific ordering of the parameters and no requirements for any parameter to be specified. /modify on its own would display help for /modify as it does already.
> Thoughts?

I have basically implemented it with backward compatibility, so you can use the /modify command in both ways.

Me and EvilSeph have done some testing for the most part it seems to work fine.
I've included checks for several possible null string errors. ( Should be all of them. )

The codes pretty messy now, mainly because /modify was pretty nasty to begin with, and I'd rather do a full rewrite of that section later instead of writing only half of it correctly.
