### PR TITLE
Fix for block status in onBlockDestroyed

### DIFF
--- a/src/id.java
+++ b/src/id.java
@@ -235,7 +235,9 @@ public class id extends ej
                     this.e.ad.a(n, i1, i2, i3);
             }
         } else if (paramhd.e == 3) {
-            etc.getLoader().callHook(PluginLoader.Hook.BLOCK_DESTROYED, new Object[] {e, new Block(type, x, y, z)});
+        	Block block = new Block(type, x, y, z);
+        	block.setStatus(3);
+            etc.getLoader().callHook(PluginLoader.Hook.BLOCK_DESTROYED, new Object[] {e, block});
 
             double d2 = this.e.l - (n + 0.5D);
             double d3 = this.e.m - (i1 + 0.5D);


### PR DESCRIPTION
The change to calling the BLOCK_DESTROYED hook fixed the block type but broke the block status, since the status is never set on the new block object.

Tiny fix which simply adds the correct status to the new block object.
