### PR TITLE
Changed how Time is handled. (+Previous commit)

### DIFF
--- a/src/Server.java
+++ b/src/Server.java
@@ -54,19 +54,41 @@ public class Server {
     }
 
     /**
-     * Returns current server time (0-24000)
+     * Returns actual server time (-2^63 to 2^63-1)
      * @return time server time
      */
     public long getTime() {
-        return server.e.c;
+       return server.e.c;
+    }
+    
+    /**
+     * Returns current server time (0-24000)
+     * @return time server time
+     */
+    public long getRelativeTime() {
+   	 long time = (server.e.c % 24000);
+   	 if (time < 0) // Java modulus is stupid.
+   		 time += 24000;
+       return time;
     }
 
+    /**
+     * Sets the actual server time
+     * @param time time (-2^63 to 2^63-1)
+     */
+    public void setTime(long time) {
+       server.e.c = time;
+    }
+    
     /**
      * Sets the current server time
      * @param time time (0-24000)
      */
-    public void setTime(long time) {
-        server.e.c = time;
+    public void setRelativeTime(long time) {
+       long margin = (time - server.e.c) % 24000;
+       if (margin < 0) // Java modulus is stupid.
+ 			margin += 24000;
+       server.e.c += margin;
     }
 
     /**

--- a/src/etc.java
+++ b/src/etc.java
@@ -65,7 +65,7 @@ public class etc {
         commands.put("/removewarp", "[Warp] - Removes the specified warp.");
         commands.put("/getpos", "- Displays your current position.");
         commands.put("/compass", "- Gives you a compass reading.");
-        commands.put("/time", "[Time|day|night] - Changes time");
+        commands.put("/time", "[time|'day|night|check|raw'] (rawtime) - Changes or checks the time");
         commands.put("/lighter", "- Gives you a lighter for lighting furnaces");
         commands.put("/motd", "- Displays the MOTD");
         commands.put("/modify", "[player] [key] [value] - Type /modify for more info");

--- a/src/id.java
+++ b/src/id.java
@@ -1062,21 +1062,31 @@ public class id extends ej
                 a.info(getPlayer().getName() + " issued server command: " + str);
                 this.d.a(str, this);
             } else if (split[0].equalsIgnoreCase("/time")) {
-                if (split.length != 2) {
-                    msg(Colors.Rose + "Correct usage is: /time [time|day|night]");
-                    return;
-                }
-
-                if (split[1].equalsIgnoreCase("day")) {
-                    this.d.e.c = 0;
-                } else if (split[1].equalsIgnoreCase("night")) {
-                    this.d.e.c = 13000;
+                if (split.length == 2) {
+	                if (split[1].equalsIgnoreCase("day")) {
+	               	 etc.getServer().setRelativeTime(0);
+	                } else if (split[1].equalsIgnoreCase("night")) {
+	               	 etc.getServer().setRelativeTime(13000);
+	                } else if (split[1].equalsIgnoreCase("check")) {
+	               	 msg(Colors.Rose + "The time is "+etc.getServer().getRelativeTime()+"! (RAW: "+etc.getServer().getTime()+")");
+	                } else {
+							try {
+								etc.getServer().setRelativeTime(Long.parseLong(split[1]));
+							} catch (NumberFormatException ex) {
+								msg(Colors.Rose + "Please enter numbers, not letters.");
+							}
+	                }
+                } else if (split.length == 3) {
+               	 if (split[1].equalsIgnoreCase("raw")) {
+	               	 try {
+	                	  	etc.getServer().setTime(Long.parseLong(split[2]));
+	                  } catch (NumberFormatException ex) {
+	                      msg(Colors.Rose + "Please enter numbers, not letters.");
+	                  }
+	                }
                 } else {
-                    try {
-                        this.d.e.c = Long.parseLong(split[1]);
-                    } catch (NumberFormatException ex) {
-                        msg(Colors.Rose + "Please enter numbers, not letters.");
-                    }
+               	 msg(Colors.Rose + "Correct usage is: /time [time|'day|night|check|raw'] (rawtime)");
+                   return;
                 }
             } else if (split[0].equalsIgnoreCase("/getpos")) {
                 Player p = getPlayer();


### PR DESCRIPTION
I've left setTime and getTime alone so existing plug-ins that like intricate control over time can continue to do so, but I've added...

setRelativeTime and getRelativeTime...

setRelativeTime will only ever increase the server clock, it moves it forward to the appropriate time that represents the specified time in the current or next day.

getRelativeTime will return the value from 0 to 24000 that represents the time in the current day.

The purpose for this change is to allow plugins/admins to mess around with time without ever going BACK in time, which seems to screw with redstone/growth/stuff. The server time variables has a capacity to withstand the spamming of this command for several thousand years before the time will have to go backward.

Also made some changes to how /time works. ( Legacy maintained. )

You can type /time check, to see the server and relative times, and you can type /time raw VALUE to set the server time directly. As of now the /time command respects the relative control and will never turn back time. ( This goes for day/night/any given value)
