### PR TITLE
Disable Flint & Steel Fires

### DIFF
--- a/src/etc.java
+++ b/src/etc.java
@@ -28,6 +28,7 @@ public class etc {
     private String[] itemSpawnBlacklist = null;
     private String[] motd = null;
     private boolean saveHomes = true;
+    private boolean blockFire = false;
     private boolean firstLoad = true;
     private boolean whitelistEnabled = false;
     private int playerLimit = 20;
@@ -103,6 +104,7 @@ public class etc {
             motd = properties.getString("motd", "Type /help for a list of commands.").split("@");
             playerLimit = properties.getInt("max-players", 20);
             saveHomes = properties.getBoolean("save-homes", true);
+            blockFire = properties.getBoolean("disable-lighter-fire", false);
             whitelistEnabled = properties.getBoolean("whitelist", false);
             whitelistMessage = properties.getString("whitelist-message", "Not on whitelist.");
             if (dataSourceType.equalsIgnoreCase("flatfile")) {
@@ -605,6 +607,14 @@ public class etc {
      */
     public boolean canSaveHomes() {
         return saveHomes;
+    }
+    
+    /**
+     * Returns true if the server allows lighters to work.
+     * @return true if server allows lighters to work.
+     */
+    public boolean blockFire() {
+        return blockFire;
     }
 
     /**

--- a/src/ix.java
+++ b/src/ix.java
@@ -1,0 +1,30 @@
+import java.util.Random;
+
+public class ix extends fq
+{
+  public ix(int paramInt)
+  {
+    super(paramInt);
+    this.aX = 1;
+    this.aY = 64;
+  }
+
+  public boolean a(hh paramhh, ft paramft, el paramel, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+    if (paramInt4 == 0) --paramInt2;
+    if (paramInt4 == 1) ++paramInt2;
+    if (paramInt4 == 2) --paramInt3;
+    if (paramInt4 == 3) ++paramInt3;
+    if (paramInt4 == 4) --paramInt1;
+    if (paramInt4 == 5) ++paramInt1;
+
+    int i = paramel.a(paramInt1, paramInt2, paramInt3);
+
+    if (i == 0 && !etc.getInstance().blockFire()) {
+      paramel.a(paramInt1 + 0.5D, paramInt2 + 0.5D, paramInt3 + 0.5D, "fire.ignite", 1.0F, b.nextFloat() * 0.4F + 0.8F);
+      paramel.d(paramInt1, paramInt2, paramInt3, fw.as.bi);
+    }
+
+    paramhh.a(1);
+    return true;
+  }
+}


### PR DESCRIPTION
This code adds a live togglable state to the server ( in etc ) that can allow or disallow fires started by flint & steel. ( This effectively lets an admin change the setting without installing/removing a mod. )

It defaults to allowing the fires, since this would be the usual operation.

You can prevent such fires by changing disable-lighter-fire to true in the server.properties.

NOTE: The docs I wrote above the boolean get is incorrect, can you please change it from 'allow' to 'disallow'
