### PR TITLE
Basic block physics

### DIFF
--- a/src/PluginListener.java
+++ b/src/PluginListener.java
@@ -337,14 +337,15 @@ public abstract class PluginListener {
 
     /**
      * Called when the game is checking the physics for a certain block.
-     * This method is called frequently and often every time a block nearby is
-     * changed.
-     * Currently the only supported block is Portal.
+     * This method is called frequently whenever a nearby block is changed,
+     * or if the block has just been placed.
+     * Currently the only supported blocks are sand, gravel and portals.
      *
      * @param block Block which requires special physics
+     * @param boolean true if this block has just been placed
      * @return true if you do want to stop the default physics for this block
      */
-    public boolean onBlockSpecialPhysics(Block block) {
+    public boolean onBlockPhysics(Block block, boolean placed) {
     	return false;
     }
 }

--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -124,9 +124,9 @@ public class PluginLoader {
          */
         MOB_SPAWN,
         /**
-         * Calls onBlockSpecialPhysics
+         * Calls onBlockPhysics
          */
-        BLOCK_SPECIAL_PHYSICS,
+        BLOCK_PHYSICS,
         /**
          * Unused.
          */
@@ -465,8 +465,8 @@ public class PluginLoader {
                                     toRet = true;
                                 }
                                 break;
-                            case BLOCK_SPECIAL_PHYSICS:
-                                if (listener.onBlockSpecialPhysics((Block) parameters[0])) {
+                            case BLOCK_PHYSICS:
+                                if (listener.onBlockPhysics((Block) parameters[0], (Boolean) parameters[1])) {
                                     toRet = true;
                                 }
                                 break;

--- a/src/ai.java
+++ b/src/ai.java
@@ -16,6 +16,7 @@ public class ai extends ht // Portal blocks (id=90)
 
     public void a(iq iq1, int i, int j, int k)
     {
+        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(bh, i, j, k), true})) return;
         if(iq1.a(i - 1, j, k) == bh || iq1.a(i + 1, j, k) == bh)
         {
             float f = 0.5F;
@@ -84,7 +85,7 @@ public class ai extends ht // Portal blocks (id=90)
 
     public void b(em em1, int i, int j, int k, int l)
     {
-        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_SPECIAL_PHYSICS, new Object[] {new Block(l, i, j, k)})) return;
+        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(l, i, j, k), false})) return;
         int i1 = 0;
         int j1 = 1;
         if(em1.a(i - 1, j, k) == bh || em1.a(i + 1, j, k) == bh)

--- a/src/fr.java
+++ b/src/fr.java
@@ -10,13 +10,13 @@ public class fr extends fy // Sand blocks (+ gravel inherits)
 
     public void e(em em1, int i, int j, int k)
     {
-        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_SPECIAL_PHYSICS, new Object[] {new Block(bh, i, j, k)})) return;
+        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(bh, i, j, k), true})) return;
         em1.h(i, j, k, bh);
     }
 
     public void b(em em1, int i, int j, int k, int l)
     {
-        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_SPECIAL_PHYSICS, new Object[] {new Block(bh, i, j, k)})) return;
+        if ((Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(l, i, j, k), false})) return;
         em1.h(i, j, k, bh);
     }
 


### PR DESCRIPTION
This is an incomplete hook, because the direction it goes in from here might get a little complicated. However, it will certainly add a lot of new possibilities for plugins to alter exactly how the world should behave.

This adds one new hook, "boolean onBlockPhysics(Block block, boolean placed)". This is currently once called whenever either a portal block, or a block with gravity, is placed, and once again every time after when the game checks the physics for that block (for example, the block under it has vanished).

The reasoning for the portal is that currently it uses unique physics that no plugin can override. With this hook, plugins can check themselves whether or not to override the server in deleting the block.
The reasoning for the gravity blocks is because they use more advanced physics than others, and would allow for some cool concepts such as anti-gravity or magnets. An example of a magnet would be http://i.imgur.com/ZKvPw.png (A simple "if (above.getType() == iron) return true;")

This should eventually be extended to trigger for every block in the game, however that would mean a dozen extra files + more overhead for plugins being called about blocks they don't need. I'm thinking a new type of hook should be added for this, to let plugins specify what blocks they're listening for and only call on that. However, that's something to think about later.

The ideas for this once all blocks have been added will open up a whole new area of plugin development. From a plugin knowing if a block was successfully placed, to antigravity, or even to full gravity. It might even be possible to use this to spawn natural landmarks whenever a chunk is created.
