### PR TITLE
Redstone hook

### DIFF
--- a/src/PluginListener.java
+++ b/src/PluginListener.java
@@ -334,4 +334,22 @@ public abstract class PluginListener {
     public boolean onMobSpawn(Mob mob) {
     	return false;
     }
+
+    /*
+     * Called whenever a redstone source (wire, switch, torch) changes its
+     * current.
+     *
+     * Standard values for wires are 0 for no current, and 14 for a strong current.
+     * Default behaviour for redstone wire is to lower the current by one every
+     * block.
+     *
+     * For other blocks which provide a source of redstone current, the current
+     * value will be 1 or 0 for on and off respectively.
+     *
+     * @param redstone Block of redstone which has just changed in current
+     * @param oldLevel the old current
+     * @param newLevel the new current
+     */
+    public void onRedstoneChange(Block block, int oldLevel, int newLevel) {
+    }
 }

--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -124,6 +124,10 @@ public class PluginLoader {
          */
         MOB_SPAWN,
         /**
+         * Calls onRedstoneChange
+         */
+        REDSTONE_CHANGE,
+        /**
          * Unused.
          */
         NUM_HOOKS
@@ -460,6 +464,9 @@ public class PluginLoader {
                                 if (listener.onMobSpawn((Mob) parameters[0])) {
                                     toRet = true;
                                 }
+                                break;
+                            case REDSTONE_CHANGE:
+                                listener.onRedstoneChange((Block) parameters[0], (Integer) parameters[1], (Integer) parameters[2]);
                                 break;
                         }
                     } catch (UnsupportedOperationException ex) {

--- a/src/ap.java
+++ b/src/ap.java
@@ -1,0 +1,242 @@
+
+import java.util.Random;
+
+public class ap extends fy {
+
+    protected ap(int paramInt1, int paramInt2) {
+        super(paramInt1, paramInt2, jt.n);
+        a(true);
+    }
+
+    public dt d(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return null;
+    }
+
+    public int b() {
+        return 20;
+    }
+
+    public boolean a() {
+        return false;
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            return true;
+        }
+        if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            return true;
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            return true;
+        }
+        return paramem.d(paramInt1, paramInt2, paramInt3 + 1);
+    }
+
+    public void c(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+
+        int j = i & 0x8;
+        i &= 7;
+
+        if ((paramInt4 == 2) && (paramem.d(paramInt1, paramInt2, paramInt3 + 1))) {
+            i = 4;
+        }
+        if ((paramInt4 == 3) && (paramem.d(paramInt1, paramInt2, paramInt3 - 1))) {
+            i = 3;
+        }
+        if ((paramInt4 == 4) && (paramem.d(paramInt1 + 1, paramInt2, paramInt3))) {
+            i = 2;
+        }
+        if ((paramInt4 == 5) && (paramem.d(paramInt1 - 1, paramInt2, paramInt3))) {
+            i = 1;
+        }
+
+        paramem.b(paramInt1, paramInt2, paramInt3, i + j);
+    }
+
+    public void e(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 1);
+        } else if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 2);
+        } else if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 3);
+        } else if (paramem.d(paramInt1, paramInt2, paramInt3 + 1)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 4);
+        }
+        g(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (g(paramem, paramInt1, paramInt2, paramInt3)) {
+            int i = paramem.b(paramInt1, paramInt2, paramInt3) & 0x7;
+            int j = 0;
+
+            if ((!paramem.d(paramInt1 - 1, paramInt2, paramInt3)) && (i == 1)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1 + 1, paramInt2, paramInt3)) && (i == 2)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1, paramInt2, paramInt3 - 1)) && (i == 3)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1, paramInt2, paramInt3 + 1)) && (i == 4)) {
+                j = 1;
+            }
+
+            if (j != 0) {
+                a_(paramem, paramInt1, paramInt2, paramInt3, paramem.b(paramInt1, paramInt2, paramInt3));
+                paramem.d(paramInt1, paramInt2, paramInt3, 0);
+            }
+        }
+    }
+
+    private boolean g(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (!a(paramem, paramInt1, paramInt2, paramInt3)) {
+            a_(paramem, paramInt1, paramInt2, paramInt3, paramem.b(paramInt1, paramInt2, paramInt3));
+            paramem.d(paramInt1, paramInt2, paramInt3, 0);
+            return false;
+        }
+        return true;
+    }
+
+    public void a(iq paramiq, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramiq.b(paramInt1, paramInt2, paramInt3);
+        int j = i & 0x7;
+        int k = (i & 0x8) > 0 ? 1 : 0;
+
+        float f1 = 0.375F;
+        float f2 = 0.625F;
+        float f3 = 0.1875F;
+        float f4 = 0.125F;
+        if (k != 0) {
+            f4 = 0.0625F;
+        }
+
+        if (j == 1) {
+            a(0.0F, f1, 0.5F - f3, f4, f2, 0.5F + f3);
+        } else if (j == 2) {
+            a(1.0F - f4, f1, 0.5F - f3, 1.0F, f2, 0.5F + f3);
+        } else if (j == 3) {
+            a(0.5F - f3, f1, 0.0F, 0.5F + f3, f2, f4);
+        } else if (j == 4) {
+            a(0.5F - f3, f1, 1.0F - f4, 0.5F + f3, f2, 1.0F);
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, fv paramfv) {
+        a(paramem, paramInt1, paramInt2, paramInt3, paramfv);
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3, fv paramfv) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        int j = i & 0x7;
+        int k = 8 - (i & 0x8);
+        if (k == 0) {
+            return true;
+        }
+
+        paramem.b(paramInt1, paramInt2, paramInt3, j + k);
+        paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+
+        paramem.a(paramInt1 + 0.5D, paramInt2 + 0.5D, paramInt3 + 0.5D, "random.click", 0.3F, 0.6F);
+
+        paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+        if (j == 1) {
+            paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 2) {
+            paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 3) {
+            paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+        } else if (j == 4) {
+            paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+        } else {
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        }
+
+        paramem.h(paramInt1, paramInt2, paramInt3, this.bh);
+
+        etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(this.bh, paramInt1, paramInt2, paramInt3), 0, 1});
+
+        return true;
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if ((i & 0x8) > 0) {
+            paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+            int j = i & 0x7;
+            if (j == 1) {
+                paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+            } else if (j == 2) {
+                paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+            } else if (j == 3) {
+                paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+            } else if (j == 4) {
+                paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+            } else {
+                paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            }
+        }
+        super.b(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        return (paramiq.b(paramInt1, paramInt2, paramInt3) & 0x8) > 0;
+    }
+
+    public boolean d(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if ((i & 0x8) == 0) {
+            return false;
+        }
+        int j = i & 0x7;
+
+        if ((j == 5) && (paramInt4 == 1)) {
+            return true;
+        }
+        if ((j == 4) && (paramInt4 == 2)) {
+            return true;
+        }
+        if ((j == 3) && (paramInt4 == 3)) {
+            return true;
+        }
+        if ((j == 2) && (paramInt4 == 4)) {
+            return true;
+        }
+        return (j == 1) && (paramInt4 == 5);
+    }
+
+    public boolean c() {
+        return true;
+    }
+
+    public void a(em paramem, int paramInt1, int paramInt2, int paramInt3, Random paramRandom) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if ((i & 0x8) == 0) {
+            return;
+        }
+        paramem.b(paramInt1, paramInt2, paramInt3, i & 0x7);
+
+        etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(this.bh, paramInt1, paramInt2, paramInt3), 1, 0});
+
+        paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+        int j = i & 0x7;
+        if (j == 1) {
+            paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 2) {
+            paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 3) {
+            paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+        } else if (j == 4) {
+            paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+        } else {
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        }
+
+        paramem.a(paramInt1 + 0.5D, paramInt2 + 0.5D, paramInt3 + 0.5D, "random.click", 0.3F, 0.5F);
+        paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+    }
+}

--- a/src/bd.java
+++ b/src/bd.java
@@ -1,0 +1,145 @@
+
+import java.util.List;
+import java.util.Random;
+
+public class bd extends fy {
+
+    private dc a;
+
+    protected bd(int paramInt1, int paramInt2, dc paramdc) {
+        super(paramInt1, paramInt2, jt.d);
+        this.a = paramdc;
+        a(true);
+
+        float f = 0.0625F;
+        a(f, 0.0F, f, 1.0F - f, 0.03125F, 1.0F - f);
+    }
+
+    public int b() {
+        return 20;
+    }
+
+    public dt d(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return null;
+    }
+
+    public boolean a() {
+        return false;
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return paramem.d(paramInt1, paramInt2 - 1, paramInt3);
+    }
+
+    public void e(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        int i = 0;
+
+        if (!paramem.d(paramInt1, paramInt2 - 1, paramInt3)) {
+            i = 1;
+        }
+
+        if (i != 0) {
+            a_(paramem, paramInt1, paramInt2, paramInt3, paramem.b(paramInt1, paramInt2, paramInt3));
+            paramem.d(paramInt1, paramInt2, paramInt3, 0);
+        }
+    }
+
+    public void a(em paramem, int paramInt1, int paramInt2, int paramInt3, Random paramRandom) {
+        if (paramem.b(paramInt1, paramInt2, paramInt3) == 0) {
+            return;
+        }
+
+        g(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public void a(em paramem, int paramInt1, int paramInt2, int paramInt3, dw paramdw) {
+        if (paramem.b(paramInt1, paramInt2, paramInt3) == 1) {
+            return;
+        }
+
+        g(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    private void g(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3) == 1 ? 1 : 0;
+        int j = 0;
+
+        float f = 0.125F;
+        List localList = null;
+        if (this.a == dc.a) {
+            localList = paramem.b(null, dt.b(paramInt1 + f, paramInt2, paramInt3 + f, paramInt1 + 1 - f, paramInt2 + 0.25D, paramInt3 + 1 - f));
+        }
+        if (this.a == dc.b) {
+            localList = paramem.a(jv.class, dt.b(paramInt1 + f, paramInt2, paramInt3 + f, paramInt1 + 1 - f, paramInt2 + 0.25D, paramInt3 + 1 - f));
+        }
+        if (this.a == dc.c) {
+            localList = paramem.a(fv.class, dt.b(paramInt1 + f, paramInt2, paramInt3 + f, paramInt1 + 1 - f, paramInt2 + 0.25D, paramInt3 + 1 - f));
+        }
+        if (localList.size() > 0) {
+            j = 1;
+        }
+
+        if ((j != 0) && (i == 0)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 1);
+            paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+
+            paramem.a(paramInt1 + 0.5D, paramInt2 + 0.1D, paramInt3 + 0.5D, "random.click", 0.3F, 0.6F);
+        }
+        if ((j == 0) && (i != 0)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 0);
+            paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+
+            paramem.a(paramInt1 + 0.5D, paramInt2 + 0.1D, paramInt3 + 0.5D, "random.click", 0.3F, 0.5F);
+        }
+
+        if (i != j) {
+            etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(this.bh, paramInt1, paramInt2, paramInt3), i, j});
+        }
+
+        if (j != 0) {
+            paramem.h(paramInt1, paramInt2, paramInt3, this.bh);
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if (i > 0) {
+            paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        }
+        super.b(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public void a(iq paramiq, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramiq.b(paramInt1, paramInt2, paramInt3) == 1 ? 1 : 0;
+
+        float f = 0.0625F;
+        if (i != 0) {
+            a(f, 0.0F, f, 1.0F - f, 0.03125F, 1.0F - f);
+        } else {
+            a(f, 0.0F, f, 1.0F - f, 0.0625F, 1.0F - f);
+        }
+    }
+
+    public boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        return paramiq.b(paramInt1, paramInt2, paramInt3) > 0;
+    }
+
+    public boolean d(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (paramem.b(paramInt1, paramInt2, paramInt3) == 0) {
+            return false;
+        }
+        return paramInt4 == 1;
+    }
+
+    public boolean c() {
+        return true;
+    }
+}

--- a/src/ck.java
+++ b/src/ck.java
@@ -1,0 +1,160 @@
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class ck extends gw {
+
+    private boolean a = false;
+    private static List b = new ArrayList();
+
+    private boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3, boolean paramBoolean) {
+        if (paramBoolean) {
+            b.add(new it(paramInt1, paramInt2, paramInt3, paramem.e));
+        }
+        int i = 0;
+        for (int j = 0; j < b.size(); j++) {
+            it localit = (it) b.get(j);
+            if ((localit.a == paramInt1) && (localit.b == paramInt2) && (localit.c == paramInt3)) {
+                i++;
+                if (i >= 8) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    protected ck(int paramInt1, int paramInt2, boolean paramBoolean) {
+        super(paramInt1, paramInt2);
+        this.a = paramBoolean;
+        a(true);
+    }
+
+    public int b() {
+        return 2;
+    }
+
+    public void e(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.b(paramInt1, paramInt2, paramInt3) == 0) {
+            super.e(paramem, paramInt1, paramInt2, paramInt3);
+        }
+        if (this.a) {
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+            paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+            paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (this.a) {
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+            paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+            paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+            paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+        }
+    }
+
+    public boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (!this.a) {
+            return false;
+        }
+
+        int i = paramiq.b(paramInt1, paramInt2, paramInt3);
+
+        if ((i == 5) && (paramInt4 == 1)) {
+            return false;
+        }
+        if ((i == 3) && (paramInt4 == 3)) {
+            return false;
+        }
+        if ((i == 4) && (paramInt4 == 2)) {
+            return false;
+        }
+        if ((i == 1) && (paramInt4 == 5)) {
+            return false;
+        }
+        return (i != 2) || (paramInt4 != 4);
+    }
+
+    private boolean g(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+
+        if ((i == 5) && (paramem.j(paramInt1, paramInt2 - 1, paramInt3, 0))) {
+            return true;
+        }
+        if ((i == 3) && (paramem.j(paramInt1, paramInt2, paramInt3 - 1, 2))) {
+            return true;
+        }
+        if ((i == 4) && (paramem.j(paramInt1, paramInt2, paramInt3 + 1, 3))) {
+            return true;
+        }
+        if ((i == 1) && (paramem.j(paramInt1 - 1, paramInt2, paramInt3, 4))) {
+            return true;
+        }
+        return (i == 2) && (paramem.j(paramInt1 + 1, paramInt2, paramInt3, 5));
+    }
+
+    public void a(em paramem, int paramInt1, int paramInt2, int paramInt3, Random paramRandom) {
+        boolean bool = g(paramem, paramInt1, paramInt2, paramInt3);
+        int oldType = this.bh;
+        int newType = oldType;
+
+        while ((b.size() > 0) && (paramem.e - ((it) b.get(0)).d > 100L)) {
+            b.remove(0);
+        }
+
+        if (this.a) {
+            if (bool) {
+                paramem.b(paramInt1, paramInt2, paramInt3, fy.aP.bh, paramem.b(paramInt1, paramInt2, paramInt3));
+                newType = fy.aP.bh;
+
+                if (a(paramem, paramInt1, paramInt2, paramInt3, true)) {
+                    paramem.a(paramInt1 + 0.5F, paramInt2 + 0.5F, paramInt3 + 0.5F, "random.fizz", 0.5F, 2.6F + (paramem.l.nextFloat() - paramem.l.nextFloat()) * 0.8F);
+                    for (int i = 0; i < 5; i++) {
+                        double d1 = paramInt1 + paramRandom.nextDouble() * 0.6D + 0.2D;
+                        double d2 = paramInt2 + paramRandom.nextDouble() * 0.6D + 0.2D;
+                        double d3 = paramInt3 + paramRandom.nextDouble() * 0.6D + 0.2D;
+
+                        paramem.a("smoke", d1, d2, d3, 0.0D, 0.0D, 0.0D);
+                    }
+                }
+            }
+        } else if ((!bool)
+                && (!a(paramem, paramInt1, paramInt2, paramInt3, false))) {
+            paramem.b(paramInt1, paramInt2, paramInt3, fy.aQ.bh, paramem.b(paramInt1, paramInt2, paramInt3));
+            newType = fy.aQ.bh;
+        }
+
+        int old = (oldType == fy.aP.bh) ? 0 : 1;
+        int current = (newType == fy.aP.bh) ? 0 : 1;
+        if (old != current) {
+            etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(newType, paramInt1, paramInt2, paramInt3), old, current});
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        super.b(paramem, paramInt1, paramInt2, paramInt3, paramInt4);
+        paramem.h(paramInt1, paramInt2, paramInt3, this.bh);
+    }
+
+    public boolean d(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (paramInt4 == 0) {
+            return b((iq)paramem, paramInt1, paramInt2, paramInt3, paramInt4);
+        }
+        return false;
+    }
+
+    public int a(int paramInt, Random paramRandom) {
+        return fy.aQ.bh;
+    }
+
+    public boolean c() {
+        return true;
+    }
+}

--- a/src/du.java
+++ b/src/du.java
@@ -1,0 +1,310 @@
+
+import java.util.Random;
+
+public class du extends fy {
+
+    private boolean a = true;
+
+    public du(int paramInt1, int paramInt2) {
+        super(paramInt1, paramInt2, jt.n);
+        a(0.0F, 0.0F, 0.0F, 1.0F, 0.0625F, 1.0F);
+    }
+
+    public dt d(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return null;
+    }
+
+    public boolean a() {
+        return false;
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return paramem.d(paramInt1, paramInt2 - 1, paramInt3);
+    }
+
+    private void g(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        int j = 0;
+
+        this.a = false;
+        boolean bool = paramem.n(paramInt1, paramInt2, paramInt3);
+        this.a = true;
+        int k;
+        int m;
+        int n;
+        if (bool) {
+            j = 15;
+        } else {
+            for (k = 0; k < 4; k++) {
+                m = paramInt1;
+                n = paramInt3;
+                if (k == 0) {
+                    m--;
+                }
+                if (k == 1) {
+                    m++;
+                }
+                if (k == 2) {
+                    n--;
+                }
+                if (k == 3) {
+                    n++;
+                }
+
+                j = f(paramem, m, paramInt2, n, j);
+                if ((paramem.d(m, paramInt2, n)) && (!paramem.d(paramInt1, paramInt2 + 1, paramInt3))) {
+                    j = f(paramem, m, paramInt2 + 1, n, j);
+                } else if (!paramem.d(m, paramInt2, n)) {
+                    j = f(paramem, m, paramInt2 - 1, n, j);
+                }
+            }
+            if (j > 0) {
+                j--;
+            } else {
+                j = 0;
+            }
+        }
+        if (i != j) {
+            paramem.b(paramInt1, paramInt2, paramInt3, j);
+            paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+
+            if (j > 0) {
+                j--;
+            }
+            for (k = 0; k < 4; k++) {
+                m = paramInt1;
+                n = paramInt3;
+                int i1 = paramInt2 - 1;
+                if (k == 0) {
+                    m--;
+                }
+                if (k == 1) {
+                    m++;
+                }
+                if (k == 2) {
+                    n--;
+                }
+                if (k == 3) {
+                    n++;
+                }
+
+                if (paramem.d(m, paramInt2, n)) {
+                    i1 += 2;
+                }
+
+                int i2 = f(paramem, m, paramInt2, n, -1);
+                if ((i2 >= 0) && (i2 != j)) {
+                    g(paramem, m, paramInt2, n);
+                }
+                i2 = f(paramem, m, i1, n, -1);
+                if ((i2 >= 0) && (i2 != j)) {
+                    g(paramem, m, i1, n);
+                }
+            }
+
+            etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(this.bh, paramInt1, paramInt2, paramInt3), i, j});
+
+            if ((i == 0) || (j == 0)) {
+                paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+                paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+                paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+                paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+                paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+
+                paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+                paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+            }
+        }
+    }
+
+    private void h(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.a(paramInt1, paramInt2, paramInt3) != this.bh) {
+            return;
+        }
+
+        paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+        paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+        paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+        paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+        paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+
+        paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+    }
+
+    public void e(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        super.e(paramem, paramInt1, paramInt2, paramInt3);
+        if (paramem.z) {
+            return;
+        }
+
+        g(paramem, paramInt1, paramInt2, paramInt3);
+        paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+        paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+
+        h(paramem, paramInt1 - 1, paramInt2, paramInt3);
+        h(paramem, paramInt1 + 1, paramInt2, paramInt3);
+        h(paramem, paramInt1, paramInt2, paramInt3 - 1);
+        h(paramem, paramInt1, paramInt2, paramInt3 + 1);
+
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            h(paramem, paramInt1 - 1, paramInt2 + 1, paramInt3);
+        } else {
+            h(paramem, paramInt1 - 1, paramInt2 - 1, paramInt3);
+        }
+        if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            h(paramem, paramInt1 + 1, paramInt2 + 1, paramInt3);
+        } else {
+            h(paramem, paramInt1 + 1, paramInt2 - 1, paramInt3);
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            h(paramem, paramInt1, paramInt2 + 1, paramInt3 - 1);
+        } else {
+            h(paramem, paramInt1, paramInt2 - 1, paramInt3 - 1);
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 + 1)) {
+            h(paramem, paramInt1, paramInt2 + 1, paramInt3 + 1);
+        } else {
+            h(paramem, paramInt1, paramInt2 - 1, paramInt3 + 1);
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        super.b(paramem, paramInt1, paramInt2, paramInt3);
+        if (paramem.z) {
+            return;
+        }
+
+        paramem.g(paramInt1, paramInt2 + 1, paramInt3, this.bh);
+        paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        g(paramem, paramInt1, paramInt2, paramInt3);
+
+        h(paramem, paramInt1 - 1, paramInt2, paramInt3);
+        h(paramem, paramInt1 + 1, paramInt2, paramInt3);
+        h(paramem, paramInt1, paramInt2, paramInt3 - 1);
+        h(paramem, paramInt1, paramInt2, paramInt3 + 1);
+
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            h(paramem, paramInt1 - 1, paramInt2 + 1, paramInt3);
+        } else {
+            h(paramem, paramInt1 - 1, paramInt2 - 1, paramInt3);
+        }
+        if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            h(paramem, paramInt1 + 1, paramInt2 + 1, paramInt3);
+        } else {
+            h(paramem, paramInt1 + 1, paramInt2 - 1, paramInt3);
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            h(paramem, paramInt1, paramInt2 + 1, paramInt3 - 1);
+        } else {
+            h(paramem, paramInt1, paramInt2 - 1, paramInt3 - 1);
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 + 1)) {
+            h(paramem, paramInt1, paramInt2 + 1, paramInt3 + 1);
+        } else {
+            h(paramem, paramInt1, paramInt2 - 1, paramInt3 + 1);
+        }
+    }
+
+    private int f(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (paramem.a(paramInt1, paramInt2, paramInt3) != this.bh) {
+            return paramInt4;
+        }
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if (i > paramInt4) {
+            return i;
+        }
+        return paramInt4;
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (paramem.z) {
+            return;
+        }
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+
+        boolean bool = a(paramem, paramInt1, paramInt2, paramInt3);
+
+        if (!bool) {
+            a_(paramem, paramInt1, paramInt2, paramInt3, i);
+            paramem.d(paramInt1, paramInt2, paramInt3, 0);
+        } else {
+            g(paramem, paramInt1, paramInt2, paramInt3);
+        }
+
+        super.b(paramem, paramInt1, paramInt2, paramInt3, paramInt4);
+    }
+
+    public int a(int paramInt, Random paramRandom) {
+        return fs.aA.aW;
+    }
+
+    public boolean d(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (!this.a) {
+            return false;
+        }
+        return b((iq)paramem, paramInt1, paramInt2, paramInt3, paramInt4);
+    }
+
+    public boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (!this.a) {
+            return false;
+        }
+        if (paramiq.b(paramInt1, paramInt2, paramInt3) == 0) {
+            return false;
+        }
+
+        if (paramInt4 == 1) {
+            return true;
+        }
+
+        int i = (b(paramiq, paramInt1 - 1, paramInt2, paramInt3)) || ((!paramiq.d(paramInt1 - 1, paramInt2, paramInt3)) && (b(paramiq, paramInt1 - 1, paramInt2 - 1, paramInt3))) ? 1 : 0;
+        int j = (b(paramiq, paramInt1 + 1, paramInt2, paramInt3)) || ((!paramiq.d(paramInt1 + 1, paramInt2, paramInt3)) && (b(paramiq, paramInt1 + 1, paramInt2 - 1, paramInt3))) ? 1 : 0;
+        int k = (b(paramiq, paramInt1, paramInt2, paramInt3 - 1)) || ((!paramiq.d(paramInt1, paramInt2, paramInt3 - 1)) && (b(paramiq, paramInt1, paramInt2 - 1, paramInt3 - 1))) ? 1 : 0;
+        int m = (b(paramiq, paramInt1, paramInt2, paramInt3 + 1)) || ((!paramiq.d(paramInt1, paramInt2, paramInt3 + 1)) && (b(paramiq, paramInt1, paramInt2 - 1, paramInt3 + 1))) ? 1 : 0;
+        if (!paramiq.d(paramInt1, paramInt2 + 1, paramInt3)) {
+            if ((paramiq.d(paramInt1 - 1, paramInt2, paramInt3)) && (b(paramiq, paramInt1 - 1, paramInt2 + 1, paramInt3))) {
+                i = 1;
+            }
+            if ((paramiq.d(paramInt1 + 1, paramInt2, paramInt3)) && (b(paramiq, paramInt1 + 1, paramInt2 + 1, paramInt3))) {
+                j = 1;
+            }
+            if ((paramiq.d(paramInt1, paramInt2, paramInt3 - 1)) && (b(paramiq, paramInt1, paramInt2 + 1, paramInt3 - 1))) {
+                k = 1;
+            }
+            if ((paramiq.d(paramInt1, paramInt2, paramInt3 + 1)) && (b(paramiq, paramInt1, paramInt2 + 1, paramInt3 + 1))) {
+                m = 1;
+            }
+        }
+
+        if ((k == 0) && (j == 0) && (i == 0) && (m == 0) && (paramInt4 >= 2) && (paramInt4 <= 5)) {
+            return true;
+        }
+
+        if ((paramInt4 == 2) && (k != 0) && (i == 0) && (j == 0)) {
+            return true;
+        }
+        if ((paramInt4 == 3) && (m != 0) && (i == 0) && (j == 0)) {
+            return true;
+        }
+        if ((paramInt4 == 4) && (i != 0) && (k == 0) && (m == 0)) {
+            return true;
+        }
+        return (paramInt4 == 5) && (j != 0) && (k == 0) && (m == 0);
+    }
+
+    public boolean c() {
+        return this.a;
+    }
+
+    public static boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramiq.a(paramInt1, paramInt2, paramInt3);
+        if (i == fy.av.bh) {
+            return true;
+        }
+        if (i == 0) {
+            return false;
+        }
+        return fy.m[i].c();
+    }
+}

--- a/src/ir.java
+++ b/src/ir.java
@@ -1,0 +1,211 @@
+
+import java.util.Random;
+
+public class ir extends fy {
+
+    protected ir(int paramInt1, int paramInt2) {
+        super(paramInt1, paramInt2, jt.n);
+    }
+
+    public dt d(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        return null;
+    }
+
+    public boolean a() {
+        return false;
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            return true;
+        }
+        if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            return true;
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            return true;
+        }
+        if (paramem.d(paramInt1, paramInt2, paramInt3 + 1)) {
+            return true;
+        }
+        return paramem.d(paramInt1, paramInt2 - 1, paramInt3);
+    }
+
+    public void c(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+
+        int j = i & 0x8;
+        i &= 7;
+
+        if ((paramInt4 == 1) && (paramem.d(paramInt1, paramInt2 - 1, paramInt3))) {
+            i = 5 + paramem.l.nextInt(2);
+        }
+        if ((paramInt4 == 2) && (paramem.d(paramInt1, paramInt2, paramInt3 + 1))) {
+            i = 4;
+        }
+        if ((paramInt4 == 3) && (paramem.d(paramInt1, paramInt2, paramInt3 - 1))) {
+            i = 3;
+        }
+        if ((paramInt4 == 4) && (paramem.d(paramInt1 + 1, paramInt2, paramInt3))) {
+            i = 2;
+        }
+        if ((paramInt4 == 5) && (paramem.d(paramInt1 - 1, paramInt2, paramInt3))) {
+            i = 1;
+        }
+
+        paramem.b(paramInt1, paramInt2, paramInt3, i + j);
+    }
+
+    public void e(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (paramem.d(paramInt1 - 1, paramInt2, paramInt3)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 1);
+        } else if (paramem.d(paramInt1 + 1, paramInt2, paramInt3)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 2);
+        } else if (paramem.d(paramInt1, paramInt2, paramInt3 - 1)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 3);
+        } else if (paramem.d(paramInt1, paramInt2, paramInt3 + 1)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 4);
+        } else if (paramem.d(paramInt1, paramInt2 - 1, paramInt3)) {
+            paramem.b(paramInt1, paramInt2, paramInt3, 5 + paramem.l.nextInt(2));
+        }
+        g(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (g(paramem, paramInt1, paramInt2, paramInt3)) {
+            int i = paramem.b(paramInt1, paramInt2, paramInt3) & 0x7;
+            int j = 0;
+
+            if ((!paramem.d(paramInt1 - 1, paramInt2, paramInt3)) && (i == 1)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1 + 1, paramInt2, paramInt3)) && (i == 2)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1, paramInt2, paramInt3 - 1)) && (i == 3)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1, paramInt2, paramInt3 + 1)) && (i == 4)) {
+                j = 1;
+            }
+            if ((!paramem.d(paramInt1, paramInt2 - 1, paramInt3)) && (i == 5)) {
+                j = 1;
+            }
+
+            if (j != 0) {
+                a_(paramem, paramInt1, paramInt2, paramInt3, paramem.b(paramInt1, paramInt2, paramInt3));
+                paramem.d(paramInt1, paramInt2, paramInt3, 0);
+            }
+        }
+    }
+
+    private boolean g(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        if (!a(paramem, paramInt1, paramInt2, paramInt3)) {
+            a_(paramem, paramInt1, paramInt2, paramInt3, paramem.b(paramInt1, paramInt2, paramInt3));
+            paramem.d(paramInt1, paramInt2, paramInt3, 0);
+            return false;
+        }
+        return true;
+    }
+
+    public void a(iq paramiq, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramiq.b(paramInt1, paramInt2, paramInt3) & 0x7;
+        float f = 0.1875F;
+        if (i == 1) {
+            a(0.0F, 0.2F, 0.5F - f, f * 2.0F, 0.8F, 0.5F + f);
+        } else if (i == 2) {
+            a(1.0F - f * 2.0F, 0.2F, 0.5F - f, 1.0F, 0.8F, 0.5F + f);
+        } else if (i == 3) {
+            a(0.5F - f, 0.2F, 0.0F, 0.5F + f, 0.8F, f * 2.0F);
+        } else if (i == 4) {
+            a(0.5F - f, 0.2F, 1.0F - f * 2.0F, 0.5F + f, 0.8F, 1.0F);
+        } else {
+            f = 0.25F;
+            a(0.5F - f, 0.0F, 0.5F - f, 0.5F + f, 0.6F, 0.5F + f);
+        }
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3, fv paramfv) {
+        a(paramem, paramInt1, paramInt2, paramInt3, paramfv);
+    }
+
+    public boolean a(em paramem, int paramInt1, int paramInt2, int paramInt3, fv paramfv) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        int j = i & 0x7;
+        int k = 8 - (i & 0x8);
+
+        paramem.b(paramInt1, paramInt2, paramInt3, j + k);
+        paramem.b(paramInt1, paramInt2, paramInt3, paramInt1, paramInt2, paramInt3);
+
+        paramem.a(paramInt1 + 0.5D, paramInt2 + 0.5D, paramInt3 + 0.5D, "random.click", 0.3F, k > 0 ? 0.6F : 0.5F);
+
+        paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+        if (j == 1) {
+            paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 2) {
+            paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+        } else if (j == 3) {
+            paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+        } else if (j == 4) {
+            paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+        } else {
+            paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+        }
+
+        int old = (k == 8) ? 1 : 0;
+        int current = (k != 8) ? 1 : 0;
+        etc.getLoader().callHook(PluginLoader.Hook.REDSTONE_CHANGE, new Object[]{new Block(this.bh, paramInt1, paramInt2, paramInt3), old, current});
+
+        return true;
+    }
+
+    public void b(em paramem, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if ((i & 0x8) > 0) {
+            paramem.g(paramInt1, paramInt2, paramInt3, this.bh);
+            int j = i & 0x7;
+            if (j == 1) {
+                paramem.g(paramInt1 - 1, paramInt2, paramInt3, this.bh);
+            } else if (j == 2) {
+                paramem.g(paramInt1 + 1, paramInt2, paramInt3, this.bh);
+            } else if (j == 3) {
+                paramem.g(paramInt1, paramInt2, paramInt3 - 1, this.bh);
+            } else if (j == 4) {
+                paramem.g(paramInt1, paramInt2, paramInt3 + 1, this.bh);
+            } else {
+                paramem.g(paramInt1, paramInt2 - 1, paramInt3, this.bh);
+            }
+        }
+        super.b(paramem, paramInt1, paramInt2, paramInt3);
+    }
+
+    public boolean b(iq paramiq, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        return (paramiq.b(paramInt1, paramInt2, paramInt3) & 0x8) > 0;
+    }
+
+    public boolean d(em paramem, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        int i = paramem.b(paramInt1, paramInt2, paramInt3);
+        if ((i & 0x8) == 0) {
+            return false;
+        }
+        int j = i & 0x7;
+
+        if ((j == 5) && (paramInt4 == 1)) {
+            return true;
+        }
+        if ((j == 4) && (paramInt4 == 2)) {
+            return true;
+        }
+        if ((j == 3) && (paramInt4 == 3)) {
+            return true;
+        }
+        if ((j == 2) && (paramInt4 == 4)) {
+            return true;
+        }
+        return (j == 1) && (paramInt4 == 5);
+    }
+
+    public boolean c() {
+        return true;
+    }
+}


### PR DESCRIPTION
Currently there is no feasible way to tell when a redstone source (wire/button/etc) has just had its current altered. This limits plugin development preventing us from making things more natural with the game and instead have to resort to using commands to magically hook everything up. That's just no fun :(

This adds a simple event that gets fired every time a redstone source has its current altered. It passes the block that was changed, the old current value and the new current value. For wires this is usually 0-14 but for all other boolean sources it will return either 0 or 1.
