### PR TITLE
Update to Server class, setBlockAt thread-safe

### DIFF
--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -148,7 +148,7 @@ public class PluginLoader {
      */
     public PluginLoader(MinecraftServer server) {
         properties = new PropertiesFile("server.properties");
-        this.server = new Server(server);
+        this.server = Server.getInstance();
 
         for (int h = 0; h < Hook.NUM_HOOKS.ordinal(); ++h) {
             listeners.add(new ArrayList<PluginRegisteredListener>());

--- a/src/bw.java
+++ b/src/bw.java
@@ -1,0 +1,16 @@
+import net.minecraft.server.MinecraftServer;
+ 
+public final class bw extends Thread
+{
+	private Server wrapper;
+			
+	public bw(String paramString, MinecraftServer paramMinecraftServer)
+	{
+		super(paramString);
+		wrapper = Server.attachTo(paramMinecraftServer);
+	}
+	
+	public void run() { 
+		wrapper.run();
+	}
+}


### PR DESCRIPTION
This patch aims to allow setBlockAt to be called from multiple threads simulatenously. It does so by dispatching all calls to that particular function to an event queue, which is run periodically from the main server loop, thus ensuring it to be run from the Server Thread.
