### PR TITLE
Physics hook

### DIFF
--- a/src/PluginListener.java
+++ b/src/PluginListener.java
@@ -397,4 +397,18 @@ public abstract class PluginListener {
     public int onRedstoneChange(Block block, int oldLevel, int newLevel) {
         return newLevel;
     }
+
+    /**
+     * Called when the game is checking the physics for a certain block.
+     * This method is called frequently whenever a nearby block is changed,
+     * or if the block has just been placed.
+     * Currently the only supported blocks are sand, gravel and portals.
+     *
+     * @param block Block which requires special physics
+     * @param boolean true if this block has just been placed
+     * @return true if you do want to stop the default physics for this block
+     */
+    public boolean onBlockPhysics(Block block, boolean placed) {
+    	return false;
+    }
 }

--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -140,6 +140,10 @@ public class PluginLoader {
          */
         REDSTONE_CHANGE,
         /**
+         * Calls onBlockPhysics
+         */
+        BLOCK_PHYSICS,
+        /**
          * Unused.
          */
         NUM_HOOKS
@@ -499,6 +503,11 @@ public class PluginLoader {
                                 break;
                             case REDSTONE_CHANGE:
                                 toRet = listener.onRedstoneChange((Block) parameters[0], (Integer) parameters[1], (Integer) toRet);
+                                break;
+                            case BLOCK_PHYSICS:
+                                if (listener.onBlockPhysics((Block) parameters[0], (Boolean) parameters[1])) {
+                                    toRet = true;
+                                }
                                 break;
                         }
                     } catch (UnsupportedOperationException ex) {

--- a/src/ai.java
+++ b/src/ai.java
@@ -1,0 +1,140 @@
+
+import java.io.PrintStream;
+import java.util.Random;
+
+public class ai extends hw {
+
+    public ai(int paramInt1, int paramInt2) {
+        super(paramInt1, paramInt2, jw.x, false);
+    }
+
+    public du d(eo parameo, int paramInt1, int paramInt2, int paramInt3) {
+        return null;
+    }
+
+    public void a(it paramit, int paramInt1, int paramInt2, int paramInt3) {
+        if (!(Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(bh, paramInt1, paramInt2, paramInt3), true})) {
+            float f1;
+            float f2;
+            if ((paramit.a(paramInt1 - 1, paramInt2, paramInt3) == this.bh) || (paramit.a(paramInt1 + 1, paramInt2, paramInt3) == this.bh)) {
+                f1 = 0.5F;
+                f2 = 0.125F;
+                a(0.5F - f1, 0.0F, 0.5F - f2, 0.5F + f1, 1.0F, 0.5F + f2);
+            } else {
+                f1 = 0.125F;
+                f2 = 0.5F;
+                a(0.5F - f1, 0.0F, 0.5F - f2, 0.5F + f1, 1.0F, 0.5F + f2);
+            }
+        }
+    }
+
+    public boolean a() {
+        return false;
+    }
+
+    public boolean a_(eo parameo, int paramInt1, int paramInt2, int paramInt3) {
+        int i = 0;
+        int j = 0;
+        if ((parameo.a(paramInt1 - 1, paramInt2, paramInt3) == ga.ap.bh) || (parameo.a(paramInt1 + 1, paramInt2, paramInt3) == ga.ap.bh)) {
+            i = 1;
+        }
+        if ((parameo.a(paramInt1, paramInt2, paramInt3 - 1) == ga.ap.bh) || (parameo.a(paramInt1, paramInt2, paramInt3 + 1) == ga.ap.bh)) {
+            j = 1;
+        }
+
+        if (i == j) {
+            return false;
+        }
+
+        if (parameo.a(paramInt1 - i, paramInt2, paramInt3 - j) == 0) {
+            paramInt1 -= i;
+            paramInt3 -= j;
+        }
+        int m;
+        for (int k = -1; k <= 2; k++) {
+            for (m = -1; m <= 3; m++) {
+                int n = (k == -1) || (k == 2) || (m == -1) || (m == 3) ? 1 : 0;
+                if (((k == -1) || (k == 2)) && ((m == -1) || (m == 3))) {
+                    continue;
+                }
+                int i1 = parameo.a(paramInt1 + i * k, paramInt2 + m, paramInt3 + j * k);
+
+                if (n != 0) {
+                    if (i1 != ga.ap.bh) {
+                        return false;
+                    }
+                } else if ((i1 != 0) && (i1 != ga.ar.bh)) {
+                    return false;
+                }
+            }
+
+        }
+
+        parameo.i = true;
+        for (int k = 0; k < 2; k++) {
+            for (m = 0; m < 3; m++) {
+                parameo.d(paramInt1 + i * k, paramInt2 + m, paramInt3 + j * k, ga.be.bh);
+            }
+        }
+        parameo.i = false;
+
+        return true;
+    }
+
+    public void b(eo parameo, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (!(Boolean) etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[]{new Block(bh, paramInt1, paramInt2, paramInt3), false})) {
+            int i = 0;
+            int j = 1;
+            if ((parameo.a(paramInt1 - 1, paramInt2, paramInt3) == this.bh) || (parameo.a(paramInt1 + 1, paramInt2, paramInt3) == this.bh)) {
+                i = 1;
+                j = 0;
+            }
+
+            int k = paramInt2;
+            while (parameo.a(paramInt1, k - 1, paramInt3) == this.bh) {
+                k--;
+            }
+            if (parameo.a(paramInt1, k - 1, paramInt3) != ga.ap.bh) {
+                parameo.d(paramInt1, paramInt2, paramInt3, 0);
+                return;
+            }
+
+            int m = 1;
+            while ((m < 4) && (parameo.a(paramInt1, k + m, paramInt3) == this.bh)) {
+                m++;
+            }
+            if ((m != 3) || (parameo.a(paramInt1, k + m, paramInt3) != ga.ap.bh)) {
+                parameo.d(paramInt1, paramInt2, paramInt3, 0);
+                return;
+            }
+
+            int n = (parameo.a(paramInt1 - 1, paramInt2, paramInt3) == this.bh) || (parameo.a(paramInt1 + 1, paramInt2, paramInt3) == this.bh) ? 1 : 0;
+            int i1 = (parameo.a(paramInt1, paramInt2, paramInt3 - 1) == this.bh) || (parameo.a(paramInt1, paramInt2, paramInt3 + 1) == this.bh) ? 1 : 0;
+            if ((n != 0) && (i1 != 0)) {
+                parameo.d(paramInt1, paramInt2, paramInt3, 0);
+                return;
+            }
+
+            if (((parameo.a(paramInt1 + i, paramInt2, paramInt3 + j) != ga.ap.bh) || (parameo.a(paramInt1 - i, paramInt2, paramInt3 - j) != this.bh)) && ((parameo.a(paramInt1 - i, paramInt2, paramInt3 - j) != ga.ap.bh) || (parameo.a(paramInt1 + i, paramInt2, paramInt3 + j) != this.bh))) {
+                parameo.d(paramInt1, paramInt2, paramInt3, 0);
+                return;
+            }
+        }
+    }
+
+    public boolean a(it paramit, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        return true;
+    }
+
+    public int a(Random paramRandom) {
+        return 0;
+    }
+
+    public void a(eo parameo, int paramInt1, int paramInt2, int paramInt3, dx paramdx) {
+        if (parameo.z) {
+            return;
+        }
+
+        paramdx.D();
+    }
+}

--- a/src/ft.java
+++ b/src/ft.java
@@ -1,0 +1,61 @@
+
+import java.util.Random;
+
+public class ft extends ga { // Sand block (gravel inherits)
+
+    public static boolean a = false;
+
+    public ft(int paramInt1, int paramInt2) {
+        super(paramInt1, paramInt2, jw.m);
+    }
+
+    public void e(eo parameo, int paramInt1, int paramInt2, int paramInt3) {
+        if (!(Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(bh, paramInt1, paramInt2, paramInt3), true})) {
+            parameo.h(paramInt1, paramInt2, paramInt3, this.bh);
+        }
+    }
+
+    public void b(eo parameo, int paramInt1, int paramInt2, int paramInt3, int paramInt4) {
+        if (!(Boolean)etc.getLoader().callHook(PluginLoader.Hook.BLOCK_PHYSICS, new Object[] {new Block(bh, paramInt1, paramInt2, paramInt3), false})) {
+            parameo.h(paramInt1, paramInt2, paramInt3, this.bh);
+        }
+    }
+
+    public void a(eo parameo, int paramInt1, int paramInt2, int paramInt3, Random paramRandom) {
+        h(parameo, paramInt1, paramInt2, paramInt3);
+    }
+
+    private void h(eo parameo, int paramInt1, int paramInt2, int paramInt3) {
+        int i = paramInt1;
+        int j = paramInt2;
+        int k = paramInt3;
+        if ((g(parameo, i, j - 1, k)) && (j >= 0)) {
+            ib localib = new ib(parameo, paramInt1 + 0.5F, paramInt2 + 0.5F, paramInt3 + 0.5F, this.bh);
+            if (a) {
+                while (!localib.G) {
+                    localib.b_();
+                }
+            }
+            parameo.a(localib);
+        }
+    }
+
+    public int b() {
+        return 3;
+    }
+
+    public static boolean g(eo parameo, int paramInt1, int paramInt2, int paramInt3) {
+        int i = parameo.a(paramInt1, paramInt2, paramInt3);
+        if (i == 0) {
+            return true;
+        }
+        if (i == ga.ar.bh) {
+            return true;
+        }
+        jw localjw = ga.m[i].bs;
+        if (localjw == jw.f) {
+            return true;
+        }
+        return localjw == jw.g;
+    }
+}


### PR DESCRIPTION
I'll just copy from the previous request:

This is an incomplete hook, because the direction it goes in from here might get a little complicated. However, it will certainly add a lot of new possibilities for plugins to alter exactly how the world should behave.

This adds one new hook, "boolean onBlockPhysics(Block block, boolean placed)". This is currently once called whenever either a portal block, or a block with gravity, is placed, and once again every time after when the game checks the physics for that block (for example, the block under it has vanished).

The reasoning for the portal is that currently it uses unique physics that no plugin can override. With this hook, plugins can check themselves whether or not to override the server in deleting the block.
The reasoning for the gravity blocks is because they use more advanced physics than others, and would allow for some cool concepts such as anti-gravity or magnets. An example of a magnet would be http://i.imgur.com/ZKvPw.png (A simple "if (above.getType() == iron) return true;")

This should eventually be extended to trigger for every block in the game, however that would mean a dozen extra files + more overhead for plugins being called about blocks they don't need. I'm thinking a new type of hook should be added for this, to let plugins specify what blocks they're listening for and only call on that. However, that's something to think about later.

The ideas for this once all blocks have been added will open up a whole new area of plugin development. From a plugin knowing if a block was successfully placed, to antigravity, or even to full gravity. It might even be possible to use this to spawn natural landmarks whenever a chunk is created.
