### PR TITLE
Fix for autoheal property

### DIFF
--- a/src/fy.java
+++ b/src/fy.java
@@ -60,7 +60,7 @@ public class fy extends jz {
     	  //above me is allowing the default action, auto-heal=default 
     	  //below is if you set autoheal=true
     	  //no attempting to auto-heal if auto-heal=false
-        if (etc.getInstance().autoHeal() == PluginLoader.HookResult.ALLOW_ACTION) {
+        else if (etc.getInstance().autoHeal() == PluginLoader.HookResult.ALLOW_ACTION) {
             if ((this.aR < 20) && (this.X % 20 * 4 == 0)) {
                 a(1);
             }


### PR DESCRIPTION
The eventually-accepted modification of my previous pull request code accidentally kills the functionality of setting auto-heal=true.  

Note the difference between the two if statements. 

First one (default mode, what everyone will experience unless they change it) behaves just like notch intended, checks if monsters-spawn=false and then autoheals

Second one (auto-heal=true) will autoheal as long as you need health.

The two most recent commits contribute to this request.  Most recent is simply adding an else.
