### PR TITLE
Add requiredplugins to ensure certain plugins always load

### DIFF
--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -304,7 +304,7 @@ public class PluginLoader {
      */
     public boolean loadPlugin(String fileName) {
         if (getPlugin(fileName) != null) {
-            return; // Already exists.
+            return true; // Already exists.
         }
         return load(fileName);
     }


### PR DESCRIPTION
Although hmod includes hooks for TNT/fire related things, we currently have to directly patch it each time to ensure that the nerfs are included. If this were in a plugin (where it should be), we face the possibility of having the plugin go unloaded (which can be disastrous on a highly populated server with TNT around everywhere).

This patch adds a "requiredplugins" option. If the plugin loader fails to load one of these plugins, it stops execution of the script.

I'm not sure on the System.exit() call, however. Perhaps there is another method that this should call instead to ensure no data loss, but I believe plugin loading is early enough to have none.
