### PR TITLE
Users without "ignore restrictions" can't spawn items.

### DIFF
--- a/src/Player.java
+++ b/src/Player.java
@@ -509,7 +509,14 @@ public class Player extends HumanEntity {
                         if (amount > 1024) {
                             amount = 1024; // 16 stacks worth. More than enough.
                         }
-                        boolean allowedItem = etc.getInstance().getAllowedItems().contains(itemId) && !etc.getInstance().getDisallowedItems().contains(itemId);
+                        
+                        boolean allowedItem = false;
+                        if ((!etc.getInstance().getAllowedItems().isEmpty()) && (!canIgnoreRestrictions()) && (etc.getInstance().getAllowedItems().contains(itemId))) {
+                            allowedItem = true;
+                        } else allowedItem = true;
+                        if ((!etc.getInstance().getDisallowedItems().isEmpty()) && (!canIgnoreRestrictions()) && (etc.getInstance().getDisallowedItems().contains(itemId)))
+                            allowedItem = false;
+                        
                         if (Item.isValidItem(itemId)) {
                             if (allowedItem || canIgnoreRestrictions()) {
                                 log.log(Level.INFO, "Giving " + toGive.getName() + " some " + itemId);


### PR DESCRIPTION
Fixed being unable to spawn items with /item if user cannot ignore restrictions.

Please note: changes made by Grum (changing allowed and disallowed items from String to Int) will break a lot of configs as some people use names instead of IDs.
