### PR TITLE
An onBurn hook for fire that gets called when fire destroys a block

### DIFF
--- a/src/PluginListener.java
+++ b/src/PluginListener.java
@@ -557,4 +557,18 @@ public abstract class PluginListener {
     public boolean onAttack(LivingEntity attacker, LivingEntity defender, Integer amount) {
         return false;
     }
+    
+    /**
+     * Called when a block is destroyed by fire
+     * block status depends on type of destruction:
+     * 1 = replaced with air.
+     * 3 = replaced with fire.
+     * @param block
+     *          block to be destroyed.
+     *
+     * @return true if you dont the block to be destroyed.
+     */
+    public boolean onBurn(Block block) {
+        return false;
+    }
 }

--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -190,6 +190,10 @@ public class PluginLoader {
          */
         ATTACK,
         /**
+         * Calls onBurn
+         */
+        BURN,
+        /**
          * Unused.
          */
         NUM_HOOKS
@@ -650,6 +654,11 @@ public class PluginLoader {
                                 break;
                             case ATTACK:
                                 if (listener.onAttack((LivingEntity) parameters[0], (LivingEntity) parameters[1], (Integer) parameters[2])) {
+                                    toRet = true;
+                                }
+                                break;
+                            case BURN:
+                                if (listener.onBurn((Block) parameters[0])) {
                                     toRet = true;
                                 }
                                 break;

--- a/src/jt.java
+++ b/src/jt.java
@@ -107,11 +107,16 @@ public class jt extends gc {
                 // hMod: VERY SLOW dynamic spreading of fire.
                 Block block = new Block(parameq.a(paramInt1, paramInt2, paramInt3), paramInt1, paramInt2, paramInt3);
                 block.setStatus(3);
-                if (!(Boolean) etc.getLoader().callHook(PluginLoader.Hook.IGNITE, block, null)) {
+                if (!(Boolean) etc.getLoader().callHook(PluginLoader.Hook.IGNITE, block, null) && 
+                    !(Boolean) etc.getLoader().callHook(PluginLoader.Hook.BURN, block)) {
                     parameq.d(paramInt1, paramInt2, paramInt3, this.bh);
                 }
             } else {
-                parameq.d(paramInt1, paramInt2, paramInt3, 0);
+                Block block = new Block(parameq.a(paramInt1, paramInt2, paramInt3), paramInt1, paramInt2, paramInt3);
+                block.setStatus(1);
+                if (!(Boolean) etc.getLoader().callHook(PluginLoader.Hook.BURN, block)) {
+                    parameq.d(paramInt1, paramInt2, paramInt3, 0);
+                }
             }
             if (j != 0) {
                 gc.am.a(parameq, paramInt1, paramInt2, paramInt3, 0);


### PR DESCRIPTION
In one case fire destroys a block and then also spreads into the destroyed block, for that to happen both the IGNITE and the BURN checks need to be allowed.
