### PR TITLE
Fix for broken Player comparison

### DIFF
--- a/src/Player.java
+++ b/src/Player.java
@@ -1393,10 +1393,7 @@ public class Player extends HumanEntity implements MessageReceiver {
             return false;
         }
         final Player other = (Player) obj;
-        if (this.id != other.id) {
-            return false;
-        }
-        return true;
+        return getName().equals( other.getName());
     }
 
     /**


### PR DESCRIPTION
The equals() function in class Player is broken. It compares using the 'id' field which is generally the same for all players. (There was no equals() function in b124, for example, and there the comparison worked OK.)

While deleting the equals() function again might work, I presume it was added into Player for a reason. This one line change fixes the comparison by using getId() which returns the unique id of the associated base entity. (The other way to fix this is to compare player names, but getId() seems like the correct way to me and is a bit faster than a string comparison.)
