### PR TITLE
A proper fix for Player equals()

### DIFF
--- a/src/Player.java
+++ b/src/Player.java
@@ -1393,10 +1393,7 @@ public class Player extends HumanEntity implements MessageReceiver {
             return false;
         }
         final Player other = (Player) obj;
-        if (this.id != other.id) {
-            return false;
-        }
-        return true;
+        return getName().equals( other.getName());
     }
 
     /**


### PR DESCRIPTION
The function now checks for null and checks for matching class (as before) but then uses getName().equals( other.getName() ) to complete the comparison. This is better then relying on the id or even the base entity id since neither of these behave as required. (The base entity id can change due to a disconnect/reconnect.)

I built my own hMod jar and tested this with a Plugin I wrote that was broken due to this problem. The Plugin started working again with this fix in place. (This Plugin worked somewhat with b125 but was not robust due to the reliance on the default object version of equals().)

Thanks to Dinnerbone for suggesting this fix.
