### PR TITLE
Ondeathitemdrop

### DIFF
--- a/src/PluginListener.java
+++ b/src/PluginListener.java
@@ -388,6 +388,32 @@ public abstract class PluginListener {
     }
 
     /**
+     * Called when a player drops all items just prior to death. This will not
+     * prevent items from leaving a player's inventory on death nor can it
+     * prevent death, but it will prevent items from a player's inventory from
+     * falling on the ground.
+     * 
+     * @param player
+     *            Player who is dropping all items as they die.
+     * @param inventoryContents
+     *            Contents of the player's inventory.
+     * @param craftingTableContents
+     *            Contents of the player's crafting table.
+     * @param equipmentContents
+     *            Contents of the player's current equipment.
+     * @param attacker
+     *            Entity that caused the player to die, or null if there was no
+     *            such entity.
+     * @return true if you want to prevent items from being dropped, false to
+     *         allow the game to handle item dropping.
+     */
+    public boolean onDeathItemDrop(Player player, Item[] inventoryContents,
+            Item[] craftingTableContents, Item[] equipmentContents,
+            LivingEntity attacker) {
+        return false;
+    }
+
+    /**
      * Called whenever a redstone source (wire, switch, torch) changes its
      * current.
      *

--- a/src/PluginLoader.java
+++ b/src/PluginLoader.java
@@ -190,9 +190,9 @@ public class PluginLoader {
          */
         ATTACK,
         /**
-         * Unused.
+         * Calls onDeathItemDrop
          */
-        NUM_HOOKS
+        DEATH_ITEM_DROP
     }
     
     /**
@@ -214,39 +214,39 @@ public class PluginLoader {
     }
     
     public enum DamageType {
-        /*
+        /**
          * Creeper explosion
          */
         CREEPER_EXPLOSION,
-        /*
+        /**
          * Damage dealt by another entity
          */
         ENTITY,
-        /*
+        /**
          * Damage caused by explosion
          */
         EXPLOSION,
-        /*
+        /**
          * Damage caused from falling (fall distance - 3.0)
          */
         FALL,
-        /*
+        /**
          * Damage caused by fire (1)
          */
         FIRE,
-        /*
+        /**
          * Low periodic damage caused by burning (1)
          */
         FIRE_TICK,
-        /*
+        /**
          * Damage caused from lava (4)
          */
         LAVA,
-        /*
+        /**
          * Damage caused from drowning (2)
          */
         WATER,
-        /*
+        /**
          * Damaged caused by cactus (1)
          */
         CACTUS
@@ -268,7 +268,7 @@ public class PluginLoader {
         properties = new PropertiesFile("server.properties");
         this.server = new Server(server);
 
-        for (int h = 0; h < Hook.NUM_HOOKS.ordinal(); ++h) {
+        for (int h = 0; h < Hook.values().length; ++h) {
             listeners.add(new ArrayList<PluginRegisteredListener>());
         }
     }
@@ -341,7 +341,7 @@ public class PluginLoader {
                 log.log(Level.SEVERE, "Exception while loading class", ex);
                 return false;
             }
-            Class c = child.loadClass(fileName);
+            Class<?> c = child.loadClass(fileName);
 
             Plugin plugin = (Plugin) c.newInstance();
             plugin.setName(fileName);
@@ -538,6 +538,16 @@ public class PluginLoader {
                                 break;
                             case ITEM_DROP:
                                 if (listener.onItemDrop((Player) parameters[0], (Item) parameters[1])) {
+                                    toRet = true;
+                                }
+                                break;
+                            case DEATH_ITEM_DROP:
+                            if (listener.onDeathItemDrop(
+                                    (Player) parameters[0],
+                                    (Item[]) parameters[1],
+                                    (Item[]) parameters[2],
+                                    (Item[]) parameters[3],
+                                    (LivingEntity) parameters[4])) {
                                     toRet = true;
                                 }
                                 break;

--- a/src/et.java
+++ b/src/et.java
@@ -75,8 +75,27 @@ public class et extends fz {
     @Override
     public void f(ea paramea) {
         // hMod: drops inventory on death.
-        // TODO: HOOK MEH
-        if (etc.getInstance().isHealthEnabled()) {
+        LivingEntity attacker = (paramea != null && paramea instanceof ka) ? new LivingEntity((ka) paramea) : null;
+
+        Player player = this.getPlayer();
+        Item[] inventory = player.getInventory().getContents();
+
+        // getCraftingTable().getContents() currently returns inventory, do it the hard way
+        hn playerCraftingTable[] = player.getCraftingTable().getArray();
+        Item[] craftingTable = new Item[playerCraftingTable.length];
+        for (int i = 0; i < playerCraftingTable.length; i++) {
+            craftingTable[i] = playerCraftingTable[i] == null ? null : new Item(playerCraftingTable[i], i);
+        }
+        
+        // getEquipment().getContents() currently returns inventory, do it the hard way
+        hn playerEquipment[] = player.getEquipment().getArray();
+        Item[] equipment = new Item[playerEquipment.length];
+        for (int i = 0; i < playerEquipment.length; i++) {
+            equipment[i] = playerEquipment[i] == null? null : new Item(playerEquipment[i], i);
+        }
+        if (etc.getInstance().isHealthEnabled()
+                && !(Boolean) etc.getLoader().callHook(
+                        PluginLoader.Hook.DEATH_ITEM_DROP, player, inventory, craftingTable, equipment, attacker)) {
             this.am.f();
         }
     }


### PR DESCRIPTION
Added hook for onDeathItemDrop, when items are dropped on death. Hook does not prevent death, nor can it repopulate player inventory, equipment or crafting bench. Equipment and crafting bench item arrays passed to the hook are populated manually, as both player.getCraftingBench().getContents() and player.getEquipment().getContents() currently return the inventory item array instead of the crafting bench and equipment array, respectively.
