### PR TITLE
fix for ClassCastException when placing signs

### DIFF
--- a/src/ii.java
+++ b/src/ii.java
@@ -408,7 +408,7 @@ public class ii {
         // hMod: fix sign updating in beta 1.1_02
         // Check if bg (TileEntity) is a Sign
         if (parambm instanceof lv) {
-            d.sendPacketToChunk((jv) parambm.g(), paramInt1, paramInt2, paramInt3);
+        	d.sendPacketToChunk(((lv)parambm).g(), paramInt1, paramInt2, paramInt3);
         }
         // end hMod
     }

--- a/src/kj.java
+++ b/src/kj.java
@@ -137,7 +137,7 @@ public class kj {
     }
     // hMod: bring back old "send packet to chunk" method from alpha
 
-    public void sendPacketToChunk(jv packetToSend, int globalx, int globaly, int globalz) {
+    public void sendPacketToChunk(kx packetToSend, int globalx, int globaly, int globalz) {
         // Get chunk coordinates
         int chunkx = globalx >> 4;
         int chunkz = globalz >> 4;


### PR DESCRIPTION
Fixes error I saw when testing craftbook by placing signs:
[WARNING] Failed to handle packet: java.lang.ClassCastException: hh cannot be cast to jv
java.lang.ClassCastException: hh cannot be cast to jv
        at ii.a(ii.java:411)
        at fz.a(SourceFile:48)
        at fv.b(SourceFile:1643)
        at bm.d(bm.java:63)
        at lp.a(lp.java:630)
        at hh.a(SourceFile:39)
        at ca.a(SourceFile:232)
        at lp.a(lp.java:60)
        at ev.a(ev.java:79)
        at net.minecraft.server.MinecraftServer.h(SourceFile:297)
        at net.minecraft.server.MinecraftServer.run(SourceFile:235)
        at cu.run(SourceFile:512)

It looks like ii.java was given a quick fix. Based on my search through the previous hMod version, my changes _should_ follow what the previous hMod was using in ii.java and kj.java. I will admit I'm new to hMod's code though.
